### PR TITLE
selectable `updater` + dockerurl pre-release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,14 @@ inputs:
     required: false
   batches:
     description: >
-      Configuration for grouping updates together, newline separated following format:
-        label:prefix1,prefix2
+      Configuration for grouping updates together, as a nested YAML of lists:
       e.g.
-        internal:github.com/thepwagner/
-        aws:github.com/aws
+        internal: [github.com/thepwagner/]
+        aws:
+          - github.com/aws
+    required: false
+  updater:
+    description: 'Updater to use. Development flag, will be removed'
     required: false
 runs:
   using: "composite"
@@ -43,3 +46,4 @@ runs:
         INPUT_BATCHES: ${{ inputs.batches }}
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_LOG_LEVEL: ${{ inputs.log_level }}
+        INPUT_UPDATER: ${{ inputs.updater }}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -20,6 +20,7 @@ type Environment struct {
 	InputBranches string `env:"INPUT_BRANCHES"`
 	GitHubToken   string `env:"INPUT_TOKEN"`
 	InputLogLevel string `env:"INPUT_LOG_LEVEL" envDefault:"debug"`
+	InputUpdater  string `env:"INPUT_UPDATER"`
 }
 
 func ParseEnvironment() (*Environment, error) {

--- a/updater/dockerurl/check_test.go
+++ b/updater/dockerurl/check_test.go
@@ -30,11 +30,18 @@ func TestUpdater_Check(t *testing.T) {
 			},
 			update: github.String(nextVersion),
 		},
-		"pre-release version available": {
+		"pre-release version available while stable": {
 			releases: []*github.RepositoryRelease{
 				{TagName: github.String(nextVersion), Prerelease: github.Bool(true)},
 			},
 			update: nil,
+		},
+		"pre-release version available while pre-release": {
+			releases: []*github.RepositoryRelease{
+				{TagName: github.String(previousVersion), Prerelease: github.Bool(true)},
+				{TagName: github.String(nextVersion), Prerelease: github.Bool(true)},
+			},
+			update: github.String(nextVersion),
 		},
 		"many versions available": {
 			releases: []*github.RepositoryRelease{


### PR DESCRIPTION
This PR adds an `updater` input, which allows toggling between the included `updater.Updater` implementations on a repository.
Longer term I don't like the idea of having _every_ updater in the same repository; but while I'm throwing stuff at the wall for v0 it's the easiest way to keep implementations in sync.

Then it continues to change how `pre-release` releases are handled in the `dockerurl` updater:
* previously pre-releases were always ignored
* now pre-releases will be considered if the current release is also a pre-release

This is pretty specifically for https://github.com/bufbuild/buf/releases , which is always a pre-release? 🤷 , I just want to compile protobufs.