### PR TITLE
gopkg.in support

### DIFF
--- a/updater/gomod/applyupdate_test.go
+++ b/updater/gomod/applyupdate_test.go
@@ -85,6 +85,29 @@ func TestUpdater_ApplyUpdate_Major(t *testing.T) {
 	assert.Contains(t, mainGo, "github.com/caarlos0/env/v6")
 }
 
+func TestUpdater_ApplyUpdate_Major_Gopkg(t *testing.T) {
+	yaml1 := updater.Update{
+		Path:     "gopkg.in/yaml.v1",
+		Previous: "v1.0.0",
+		Next:     "v2.3.0",
+	}
+	tempDir := updatertest.ApplyUpdateToFixture(t, "gopkg", updaterFactory(gomod.WithMajorVersions(true)), yaml1)
+	uf := readModFiles(t, tempDir)
+
+	// Path is renamed in module files:
+	for _, s := range uf.GoModFiles() {
+		assert.NotContains(t, s, "gopkg.in/yaml.v1 v1.0.0")
+		assert.Contains(t, s, "gopkg.in/yaml.v2 v2.3.0")
+	}
+
+	// Path is updated in source code:
+	b, err := ioutil.ReadFile(filepath.Join(tempDir, "main.go"))
+	require.NoError(t, err)
+	mainGo := string(b)
+	assert.NotContains(t, mainGo, "gopkg.in/yaml.v1")
+	assert.Contains(t, mainGo, "gopkg.in/yaml.v2")
+}
+
 func TestUpdater_ApplyUpdate_NotInRoot(t *testing.T) {
 	tempDir := updatertest.ApplyUpdateToFixture(t, "notinroot", updaterFactory(), pkgErrors081)
 

--- a/updater/gomod/check_test.go
+++ b/updater/gomod/check_test.go
@@ -32,6 +32,17 @@ func TestUpdater_Check_NotMajorVersions(t *testing.T) {
 	assert.Equal(t, "v29", semver.Major(u.Next))
 }
 
+func TestUpdater_Check_GopkgIn(t *testing.T) {
+	u := updatertest.CheckInFixture(t, "gopkg", updaterFactory(gomod.WithMajorVersions(true)), updater.Dependency{
+		Path:    "gopkg.in/yaml.v1",
+		Version: "v1.0.0",
+	})
+	require.NotNil(t, u)
+	t.Log(u.Next)
+	assert.True(t, semver.Compare("v1", u.Next) < 0)
+	assert.NotEqual(t, "v1", semver.Major(u.Next))
+}
+
 func TestUpdater_Check_MajorVersionsNotAvailable(t *testing.T) {
 	t.Skip("expects v32 to be the latest, check https://github.com/google/go-github/tags before running")
 	latestGoGitHubMajor := updater.Dependency{

--- a/updater/gomod/dependencies_test.go
+++ b/updater/gomod/dependencies_test.go
@@ -10,7 +10,7 @@ import (
 func TestUpdater_Dependencies_Fixtures(t *testing.T) {
 	cases := map[string][]updater.Dependency{
 		"gopkg": {
-			{Path: "gopkg.in/yaml.v2", Version: "v2.3.0"},
+			{Path: "gopkg.in/yaml.v1", Version: "v1.0.0-20140924161607-9f9df34309c0"},
 		},
 		"major": {
 			{Path: "github.com/caarlos0/env/v5", Version: "v5.1.4"},

--- a/updater/gomod/dependencies_test.go
+++ b/updater/gomod/dependencies_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestUpdater_Dependencies_Fixtures(t *testing.T) {
 	cases := map[string][]updater.Dependency{
+		"gopkg": {
+			{Path: "gopkg.in/yaml.v2", Version: "v2.3.0"},
+		},
 		"major": {
 			{Path: "github.com/caarlos0/env/v5", Version: "v5.1.4"},
 			{Path: "github.com/davecgh/go-spew", Version: "v1.1.1", Indirect: true},

--- a/updater/gomod/testdata/gopkg/go.mod
+++ b/updater/gomod/testdata/gopkg/go.mod
@@ -2,4 +2,4 @@ module github.com/thepwagner/action-update-go/gopkg
 
 go 1.15
 
-require gopkg.in/yaml.v2 v2.3.0
+require gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0

--- a/updater/gomod/testdata/gopkg/go.mod
+++ b/updater/gomod/testdata/gopkg/go.mod
@@ -1,0 +1,5 @@
+module github.com/thepwagner/action-update-go/gopkg
+
+go 1.15
+
+require gopkg.in/yaml.v2 v2.3.0

--- a/updater/gomod/testdata/gopkg/go.sum
+++ b/updater/gomod/testdata/gopkg/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/updater/gomod/testdata/gopkg/go.sum
+++ b/updater/gomod/testdata/gopkg/go.sum
@@ -1,4 +1,6 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/updater/gomod/testdata/gopkg/main.go
+++ b/updater/gomod/testdata/gopkg/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v1"
 )
 
 func main() {
-	_ = yaml.NewEncoder(os.Stdout).
-		Encode(map[string]interface{}{
-			"foo": "bar",
-			"foz": "baz",
-		})
+	b, err := yaml.Marshal(map[string]interface{}{
+		"foo": "bar",
+		"foz": "baz",
+	})
+	if err != nil {
+		panic(err)
+	}
+	_, _ = os.Stdout.Write(b)
 }

--- a/updater/gomod/testdata/gopkg/main.go
+++ b/updater/gomod/testdata/gopkg/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	_ = yaml.NewEncoder(os.Stdout).
+		Encode(map[string]interface{}{
+			"foo": "bar",
+			"foz": "baz",
+		})
+}

--- a/updater/gomod/testdata/replace/go.mod
+++ b/updater/gomod/testdata/replace/go.mod
@@ -1,4 +1,4 @@
-module github.com/thepwagner/action-update-go/simple
+module github.com/thepwagner/action-update-go/replace
 
 go 1.15
 


### PR DESCRIPTION
I encountered as `gopkg.in/src-d/go-git.v3`; I used `yaml` for the harness as it's use internally.