### PR TITLE
dockerurl: shasum matching

### DIFF
--- a/updater/dockerurl/applyupdate_test.go
+++ b/updater/dockerurl/applyupdate_test.go
@@ -1,6 +1,7 @@
 package dockerurl_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -43,4 +44,23 @@ func TestUpdater_ApplyUpdate_Hash(t *testing.T) {
 
 	assert.NotContains(t, dockerfile, "ELIXIR_CHECKSUM=fc6d06ad4cc596b2b6e4f01712f718200c69f3b9c49c7d3b787f9a67b36482658490cf01109b0b0842fc9d88a27f64a9aba817231498d99fa01fa99688263d55")
 	assert.Contains(t, dockerfile, "ELIXIR_CHECKSUM=9727ae96d187d8b64e471ff0bb5694fcd1009cdcfd8b91a6b78b7542bb71fca59869d8440bb66a2523a6fec025f1d23394e7578674b942274c52b44e19ba2d43")
+}
+
+func TestUpdater_ApplyUpdate_Buf(t *testing.T) {
+	bufUpdate := updater.Update{
+		Path:     "github.com/bufbuild/buf/releases",
+		Previous: "v0.23.0",
+		Next:     "v0.24.0",
+	}
+	tempDir := updatertest.ApplyUpdateToFixture(t, "buf", updaterFactory(), bufUpdate)
+	b, err := ioutil.ReadFile(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	dockerfile := string(b)
+	fmt.Println(dockerfile)
+
+	assert.NotContains(t, dockerfile, "BUF_VERSION=v0.23.0")
+	assert.Contains(t, dockerfile, "BUF_VERSION=v0.24.0")
+
+	assert.NotContains(t, dockerfile, "BUF_CHECKSUM=096209b09e6c0e8b4e4c78b6fa40bad123f9d456cdb0b954e3939365f405ba2e")
+	assert.Contains(t, dockerfile, "BUF_CHECKSUM=656b9e223fc1361734ffe5cc015d375152a7e0c11610210f700f6a027eb4cecb")
 }

--- a/updater/dockerurl/testdata/buf/Dockerfile
+++ b/updater/dockerurl/testdata/buf/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.11 AS buf
+ARG BUF_VERSION=v0.23.0
+ARG BUF_CHECKSUM=096209b09e6c0e8b4e4c78b6fa40bad123f9d456cdb0b954e3939365f405ba2e
+
+ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
+RUN apk --no-cache add --virtual .build curl \
+  && curl -o /usr/local/bin/buf -L "$BUFF_URL" \
+  && echo "$BUF_CHECKSUM  /usr/local/bin/buf" | sha256sum -c \
+  && chmod +x /usr/local/bin/buf \
+  && apk del .build


### PR DESCRIPTION
Don't assume the shasum file is for a single asset - look the corresponding file in the previous shasum asset, then find it in the new one.
Added `bufbuild/buf` as a sample that needs this.