### PR TITLE
gomodules: multimodule support

### DIFF
--- a/updater/gomod/applyupdate.go
+++ b/updater/gomod/applyupdate.go
@@ -32,14 +32,14 @@ func (u *Updater) ApplyUpdate(ctx context.Context, update updater.Update) error 
 	}
 	for _, f := range modFiles {
 		logrus.WithField("path", f).Debug("updating go.mod file")
-		if err := u.updateGoModFile(ctx, f, update); err != nil {
+		if err := u.updateGoModule(ctx, f, update); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (u *Updater) updateGoModFile(ctx context.Context, path string, update updater.Update) error {
+func (u *Updater) updateGoModule(ctx context.Context, path string, update updater.Update) error {
 	if err := u.updateGoMod(path, update); err != nil {
 		return fmt.Errorf("updating go.mod: %w", err)
 	}

--- a/updater/gomod/check_test.go
+++ b/updater/gomod/check_test.go
@@ -1,6 +1,8 @@
 package gomod_test
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/semver"
@@ -55,4 +57,17 @@ func TestUpdater_Check_MajorVersionsNotAvailable(t *testing.T) {
 	t.Log(u.Next)
 	assert.True(t, semver.Compare("v32", u.Next) < 0)
 	assert.Equal(t, "v32", semver.Major(u.Next))
+}
+
+func TestUpdater_Check_Multimodule(t *testing.T) {
+	for _, path := range []string{"multimodule", filepath.Join("multimodule", "common")} {
+		t.Run(strings.ReplaceAll(path, string(filepath.Separator), "-"), func(t *testing.T) {
+			u := updatertest.CheckInFixture(t, path, updaterFactory(gomod.WithMajorVersions(false)), updater.Dependency{
+				Path:    "github.com/pkg/errors",
+				Version: "v0.8.0",
+			})
+			require.NotNil(t, u)
+			t.Log(u.Next)
+		})
+	}
 }

--- a/updater/gomod/dependencies.go
+++ b/updater/gomod/dependencies.go
@@ -14,13 +14,13 @@ import (
 )
 
 func (u *Updater) Dependencies(_ context.Context) ([]updater.Dependency, error) {
-	gomodFiles, err := u.collectGomodFiles()
+	goModFiles, err := u.collectGoModFiles()
 	if err != nil {
 		return nil, err
 	}
-	logrus.WithField("gomods", len(gomodFiles)).Debug("discovered go.mod files")
+	logrus.WithField("gomods", len(goModFiles)).Debug("discovered go.mod files")
 
-	deps, err := u.collectUniqueDependencies(gomodFiles)
+	deps, err := u.collectUniqueDependencies(goModFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -28,8 +28,8 @@ func (u *Updater) Dependencies(_ context.Context) ([]updater.Dependency, error) 
 	return sortUniqueDependencies(deps)
 }
 
-func (u *Updater) collectGomodFiles() ([]string, error) {
-	gomods, err := filepath.Glob(filepath.Join(u.root, "*", GoModFn))
+func (u *Updater) collectGoModFiles() ([]string, error) {
+	gomods, err := filepath.Glob(filepath.Join(u.root, "**", GoModFn))
 	if err != nil {
 		return nil, fmt.Errorf("collecting go.mod: %w", err)
 	}

--- a/updater/gomod/dependencies.go
+++ b/updater/gomod/dependencies.go
@@ -4,22 +4,64 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfile"
+	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update-go/updater"
 )
 
 func (u *Updater) Dependencies(_ context.Context) ([]updater.Dependency, error) {
-	parsed, err := u.parseGoMod()
+	gomodFiles, err := u.collectGomodFiles()
 	if err != nil {
 		return nil, err
 	}
-	return extractDependencies(parsed), nil
+	logrus.WithField("gomods", len(gomodFiles)).Debug("discovered go.mod files")
+
+	deps, err := u.collectUniqueDependencies(gomodFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return sortUniqueDependencies(deps)
 }
 
-func (u *Updater) parseGoMod() (*modfile.File, error) {
-	b, err := ioutil.ReadFile(filepath.Join(u.root, GoModFn))
+func (u *Updater) collectGomodFiles() ([]string, error) {
+	gomods, err := filepath.Glob(filepath.Join(u.root, "*", GoModFn))
+	if err != nil {
+		return nil, fmt.Errorf("collecting go.mod: %w", err)
+	}
+	rootGomod := filepath.Join(u.root, GoModFn)
+	if _, err := os.Stat(rootGomod); err == nil {
+		gomods = append(gomods, rootGomod)
+	}
+	return gomods, nil
+}
+
+func (u *Updater) collectUniqueDependencies(gomods []string) (map[string]updater.Dependency, error) {
+	deps := map[string]updater.Dependency{}
+	for _, gomod := range gomods {
+		parsed, err := u.parseGoMod(gomod)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, d := range extractDependencies(parsed) {
+			if d.Version == "" {
+				// Modules without versions are path replacements we can't affect:
+				continue
+			}
+			depKey := fmt.Sprintf("%s-%s", d.Path, d.Version)
+			deps[depKey] = d
+		}
+	}
+	return deps, nil
+}
+
+func (u *Updater) parseGoMod(path string) (*modfile.File, error) {
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening go.mod: %w", err)
 	}
@@ -59,4 +101,15 @@ func indexReplacements(parsed *modfile.File) map[string]updater.Dependency {
 		}
 	}
 	return replacements
+}
+
+func sortUniqueDependencies(deps map[string]updater.Dependency) ([]updater.Dependency, error) {
+	ret := make([]updater.Dependency, 0, len(deps))
+	for _, d := range deps {
+		ret = append(ret, d)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Path < ret[j].Path
+	})
+	return ret, nil
 }

--- a/updater/gomod/dependencies_test.go
+++ b/updater/gomod/dependencies_test.go
@@ -16,6 +16,16 @@ func TestUpdater_Dependencies_Fixtures(t *testing.T) {
 			{Path: "github.com/caarlos0/env/v5", Version: "v5.1.4"},
 			{Path: "github.com/davecgh/go-spew", Version: "v1.1.1", Indirect: true},
 		},
+		"multimodule": {
+			{Path: "github.com/pkg/errors", Version: "v0.8.0"},
+			{Path: "github.com/sirupsen/logrus", Version: "v1.5.0"},
+		},
+		"multimodule/common": {
+			{Path: "github.com/sirupsen/logrus", Version: "v1.5.0"},
+		},
+		"multimodule/cmd": {
+			{Path: "github.com/pkg/errors", Version: "v0.8.0"},
+		},
 		"notinroot": {
 			{Path: "github.com/pkg/errors", Version: "v0.8.0"},
 		},

--- a/updater/gomod/testdata/multimodule/cmd/go.mod
+++ b/updater/gomod/testdata/multimodule/cmd/go.mod
@@ -1,0 +1,10 @@
+module github.com/thepwagner/action-update-go/multimodule/cmd
+
+require (
+	github.com/pkg/errors v0.8.0
+	github.com/thepwagner/action-update-go/multimodule/common v1.0.0
+)
+
+replace github.com/thepwagner/action-update-go/multimodule/common => ../common
+
+go 1.15

--- a/updater/gomod/testdata/multimodule/cmd/go.sum
+++ b/updater/gomod/testdata/multimodule/cmd/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/updater/gomod/testdata/multimodule/cmd/main.go
+++ b/updater/gomod/testdata/multimodule/cmd/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"github.com/thepwagner/action-update-go/multimodule/common"
+)
+
+func main() {
+	err := errors.New("kaboom")
+	common.Logger().WithError(err).Info("")
+}

--- a/updater/gomod/testdata/multimodule/common/common.go
+++ b/updater/gomod/testdata/multimodule/common/common.go
@@ -1,0 +1,8 @@
+package common
+
+import "github.com/sirupsen/logrus"
+
+func Logger() logrus.FieldLogger {
+	return logrus.WithField("common", true)
+}
+

--- a/updater/gomod/testdata/multimodule/common/go.mod
+++ b/updater/gomod/testdata/multimodule/common/go.mod
@@ -1,0 +1,5 @@
+module github.com/thepwagner/action-update-go/multimodule/common
+
+go 1.15
+
+require github.com/sirupsen/logrus v1.5.0

--- a/updater/gomod/testdata/multimodule/common/go.sum
+++ b/updater/gomod/testdata/multimodule/common/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/updatertest/updatertest.go
+++ b/updatertest/updatertest.go
@@ -3,6 +3,7 @@ package updatertest
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	deepcopy "github.com/otiai10/copy"
@@ -43,8 +44,18 @@ func CheckInFixture(t *testing.T, fixture string, factory Factory, dep updater.D
 }
 
 func ApplyUpdateToFixture(t *testing.T, fixture string, factory Factory, up updater.Update) string {
-	tempDir := TempDirFromFixture(t, fixture)
-	u := factory(tempDir)
+	dir, f := filepath.Split(fixture)
+
+	var tempDir string
+	var u updater.Updater
+	if dir != "" {
+		tempDir = TempDirFromFixture(t, dir)
+		u = factory(filepath.Join(tempDir, f))
+	} else {
+		tempDir = TempDirFromFixture(t, f)
+		u = factory(tempDir)
+	}
+
 	err := u.ApplyUpdate(context.Background(), up)
 	require.NoError(t, err)
 	return tempDir


### PR DESCRIPTION
This changes the `gomodules.Updater` to operate recursively on all `go.mod` files under the root.
This allows operating on repositories that contain multiple go modules, including internal dependencies.

Tests cover operating on multiple `go.mod` files, or focusing the updater on a single `go.mod` path.
The idea is some new input may change the updater root to a subpath: you _can_ run configure each submodule individually, but recursive-by-default is a feature I liked from the `docker*` updaters.