### PR TITLE
Batched push

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     - unused
     - varcheck
     - whitespace
-
 issues:
   exclude:
+    - G101
     - G306

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
     required: true
+  signing_key:
+    default: "i deserve this"
+    description: >
+      Unique key to use for maintaining trusted metadata in PR body.
+    required: false
   log_level:
     description: 'Control debug/info/warn/error output'
     required: false

--- a/actions/schedule.go
+++ b/actions/schedule.go
@@ -55,7 +55,7 @@ func getRepoUpdater(env *cmd.Environment) (updater.Repo, *updater.RepoUpdater, e
 
 	var modRepo updater.Repo
 	if env.GitHubRepository != "" && env.GitHubToken != "" {
-		modRepo, err = gitrepo.NewGitHubRepo(gitRepo, env.GitHubRepository, env.GitHubToken)
+		modRepo, err = gitrepo.NewGitHubRepo(gitRepo, env.InputSigningKey, env.GitHubRepository, env.GitHubToken)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -16,11 +16,12 @@ type Environment struct {
 	GitHubEventPath  string `env:"GITHUB_EVENT_PATH"`
 	GitHubRepository string `env:"GITHUB_REPOSITORY"`
 
-	InputBatches  string `env:"INPUT_BATCHES"`
-	InputBranches string `env:"INPUT_BRANCHES"`
-	GitHubToken   string `env:"INPUT_TOKEN"`
-	InputLogLevel string `env:"INPUT_LOG_LEVEL" envDefault:"debug"`
-	InputUpdater  string `env:"INPUT_UPDATER"`
+	InputBatches    string `env:"INPUT_BATCHES"`
+	InputBranches   string `env:"INPUT_BRANCHES"`
+	GitHubToken     string `env:"INPUT_TOKEN"`
+	InputLogLevel   string `env:"INPUT_LOG_LEVEL" envDefault:"debug"`
+	InputUpdater    string `env:"INPUT_UPDATER"`
+	InputSigningKey []byte `env:"INPUT_SIGNING_KEY"`
 }
 
 func ParseEnvironment() (*Environment, error) {

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -1,0 +1,23 @@
+package repo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/thepwagner/action-update-go/updater"
+)
+
+type commitMessageGen func(...updater.Update) string
+
+var defaultCommitMessage = func(updates ...updater.Update) string {
+	if len(updates) == 1 {
+		update := updates[0]
+		return fmt.Sprintf("%s@%s", update.Path, update.Next)
+	}
+	var s strings.Builder
+	s.WriteString("dependency updates\n\n")
+	for _, u := range updates {
+		_, _ = fmt.Fprintf(&s, "%s@%s\n", u.Path, u.Next)
+	}
+	return s.String()
+}

--- a/repo/git_test.go
+++ b/repo/git_test.go
@@ -112,7 +112,7 @@ func TestGitRepo_Push(t *testing.T) {
 	commit, err := log.Next()
 	require.NoError(t, err)
 	t.Logf("inspecting commit %s", commit.Hash)
-	assert.Equal(t, "update github.com/test to v1.0.0", commit.Message)
+	assert.Equal(t, "github.com/test@v1.0.0", commit.Message)
 	assert.Equal(t, repo.DefaultGitIdentity.Name, commit.Author.Name)
 	assert.Equal(t, repo.DefaultGitIdentity.Email, commit.Author.Email)
 

--- a/repo/github.go
+++ b/repo/github.go
@@ -24,7 +24,7 @@ type GitHubRepo struct {
 var _ updater.Repo = (*GitHubRepo)(nil)
 
 type PullRequestContent interface {
-	Generate(context.Context, updater.Update) (title, body string, err error)
+	Generate(context.Context, ...updater.Update) (title, body string, err error)
 }
 
 func NewGitHubRepo(repo *GitRepo, repoNameOwner, token string) (*GitHubRepo, error) {
@@ -56,18 +56,18 @@ func (g *GitHubRepo) SetBranch(branch string) error       { return g.repo.SetBra
 func (g *GitHubRepo) NewBranch(base, branch string) error { return g.repo.NewBranch(base, branch) }
 
 // Push follows the git push with opening a pull request
-func (g *GitHubRepo) Push(ctx context.Context, update updater.Update) error {
-	if err := g.repo.Push(ctx, update); err != nil {
+func (g *GitHubRepo) Push(ctx context.Context, updates ...updater.Update) error {
+	if err := g.repo.Push(ctx, updates...); err != nil {
 		return err
 	}
-	if err := g.createPR(ctx, update); err != nil {
+	if err := g.createPR(ctx, updates); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (g *GitHubRepo) createPR(ctx context.Context, update updater.Update) error {
-	title, body, err := g.prContent.Generate(ctx, update)
+func (g *GitHubRepo) createPR(ctx context.Context, updates []updater.Update) error {
+	title, body, err := g.prContent.Generate(ctx, updates...)
 	if err != nil {
 		return fmt.Errorf("generating PR prContent: %w", err)
 	}

--- a/repo/github.go
+++ b/repo/github.go
@@ -27,7 +27,7 @@ type PullRequestContent interface {
 	Generate(context.Context, ...updater.Update) (title, body string, err error)
 }
 
-func NewGitHubRepo(repo *GitRepo, repoNameOwner, token string) (*GitHubRepo, error) {
+func NewGitHubRepo(repo *GitRepo, hmacKey []byte, repoNameOwner, token string) (*GitHubRepo, error) {
 	ghRepoSplit := strings.Split(repoNameOwner, "/")
 	if len(ghRepoSplit) != 2 {
 		return nil, fmt.Errorf("expected repo in OWNER/NAME format")
@@ -39,7 +39,7 @@ func NewGitHubRepo(repo *GitRepo, repoNameOwner, token string) (*GitHubRepo, err
 		owner:     ghRepoSplit[0],
 		repoName:  ghRepoSplit[1],
 		github:    ghClient,
-		prContent: NewGitHubPullRequestContent(ghClient),
+		prContent: NewGitHubPullRequestContent(ghClient, hmacKey),
 	}, nil
 }
 

--- a/repo/github_test.go
+++ b/repo/github_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewGitHubRepo(t *testing.T) {
 	gr := initGitRepo(t, plumbing.NewBranchReferenceName(branchName))
 
-	gh, err := repo.NewGitHubRepo(gr, "foo/bar", "")
+	gh, err := repo.NewGitHubRepo(gr, testKey, "foo/bar", "")
 	require.NoError(t, err)
 	assert.NotNil(t, gh)
 }

--- a/repo/pullrequest.go
+++ b/repo/pullrequest.go
@@ -2,10 +2,14 @@ package repo
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/semver"
@@ -115,4 +119,42 @@ func writePatchBlob(out io.Writer, updates ...updater.Update) {
 	_, _ = fmt.Fprintln(out, "\n```json")
 	_ = encoder.Encode(&details)
 	_, _ = fmt.Fprint(out, "```\n")
+}
+
+type SignedUpdateDescriptor struct {
+	Updates   []updater.Update `json:"updates"`
+	Signature []byte           `json:"signature"`
+}
+
+func NewSignedUpdateDescriptor(key []byte, updates ...updater.Update) (SignedUpdateDescriptor, error) {
+	signature, err := updatesHash(key, updates)
+	if err != nil {
+		return SignedUpdateDescriptor{}, err
+	}
+	return SignedUpdateDescriptor{
+		Updates:   updates,
+		Signature: signature,
+	}, nil
+}
+
+func updatesHash(key []byte, updates []updater.Update) ([]byte, error) {
+	sort.Slice(updates, func(i, j int) bool {
+		return updates[i].Path < updates[j].Path
+	})
+	hash := hmac.New(sha512.New, key)
+	if err := json.NewEncoder(hash).Encode(updates); err != nil {
+		return nil, err
+	}
+	return hash.Sum(nil), nil
+}
+
+func VerifySignedUpdateDescriptor(key []byte, descriptor SignedUpdateDescriptor) ([]updater.Update, error) {
+	calculated, err := updatesHash(key, descriptor.Updates)
+	if err != nil {
+		return nil, fmt.Errorf("calculating signature: %w", err)
+	}
+	if subtle.ConstantTimeCompare(calculated, descriptor.Signature) != 1 {
+		return nil, fmt.Errorf("invalid signature")
+	}
+	return descriptor.Updates, nil
 }

--- a/repo/pullrequest_test.go
+++ b/repo/pullrequest_test.go
@@ -25,12 +25,13 @@ var (
 		Previous: "v0.4.1",
 		Next:     "v99.88.77",
 	}
+	testKey = []byte{1, 2, 3, 4}
 )
 
-func TestGitHubPullRequestContentGenerator_Generate(t *testing.T) {
+func TestGitHubPullRequestContent_Generate(t *testing.T) {
 	token := tokenOrSkip(t)
 	client := repo.NewGitHubClient(token)
-	gen := repo.NewGitHubPullRequestContent(client)
+	gen := repo.NewGitHubPullRequestContent(client, testKey)
 
 	title, body, err := gen.Generate(context.Background(), awsSdkGo13417)
 	require.NoError(t, err)
@@ -40,19 +41,29 @@ Here is github.com/aws/aws-sdk-go v1.34.17, I hope it works.
 
 [changelog](https://github.com/aws/aws-sdk-go/blob/v1.34.17/CHANGELOG.md)
 
-`+"```json"+`
-{
-  "major": false,
-  "minor": false,
-  "patch": true
-}
-`+"```"), strings.TrimSpace(body))
+<!--::action-update-go::
+{"updates":[{"path":"github.com/aws/aws-sdk-go","previous":"v1.34.16","next":"v1.34.17"}],"signature":"HAF6zSdBBOsbrLRClce7M73tN7VhCdPB6YYhECL/ifDC6DHR0YSGXoY6JQeEaFoncJbxp/afBpY+GVE5DUfWwQ=="}
+-->
+`), strings.TrimSpace(body))
 }
 
-func TestGitHubPullRequestContentGenerator_GenerateNoChangeLog(t *testing.T) {
+func TestGitHubPullRequestContent_ParseBody(t *testing.T) {
 	token := tokenOrSkip(t)
 	client := repo.NewGitHubClient(token)
-	gen := repo.NewGitHubPullRequestContent(client)
+	gen := repo.NewGitHubPullRequestContent(client, testKey)
+
+	body := `
+<!--::action-update-go::
+{"updates":[{"path":"github.com/aws/aws-sdk-go","previous":"v1.34.16","next":"v1.34.17"}],"signature":"HAF6zSdBBOsbrLRClce7M73tN7VhCdPB6YYhECL/ifDC6DHR0YSGXoY6JQeEaFoncJbxp/afBpY+GVE5DUfWwQ=="}
+-->`
+	parsed := gen.ParseBody(body)
+	assert.Equal(t, []updater.Update{awsSdkGo13417}, parsed)
+}
+
+func TestGitHubPullRequestContent_GenerateNoChangeLog(t *testing.T) {
+	token := tokenOrSkip(t)
+	client := repo.NewGitHubClient(token)
+	gen := repo.NewGitHubPullRequestContent(client, testKey)
 
 	title, body, err := gen.Generate(context.Background(), fooBar987)
 	require.NoError(t, err)
@@ -60,19 +71,16 @@ func TestGitHubPullRequestContentGenerator_GenerateNoChangeLog(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(`
 Here is github.com/foo/bar v99.88.77, I hope it works.
 
-`+"```json"+`
-{
-  "major": true,
-  "minor": false,
-  "patch": false
-}
-`+"```"), strings.TrimSpace(body))
+<!--::action-update-go::
+{"updates":[{"path":"github.com/foo/bar","previous":"v0.4.1","next":"v99.88.77"}],"signature":"kq9CbO3rYkThJPiJgVTfhkfAG4q5aEeXuta0x3wPVdUnqQhitA/FasfJ2WftpfiZvueCnknoX04yxTM94BUn4A=="}
+-->
+`), strings.TrimSpace(body))
 }
 
-func TestGitHubPullRequestContentGenerator_GenerateMultiple(t *testing.T) {
+func TestGitHubPullRequestContent_GenerateMultiple(t *testing.T) {
 	token := tokenOrSkip(t)
 	client := repo.NewGitHubClient(token)
-	gen := repo.NewGitHubPullRequestContent(client)
+	gen := repo.NewGitHubPullRequestContent(client, testKey)
 
 	title, body, err := gen.Generate(context.Background(), awsSdkGo13417, fooBar987)
 	require.NoError(t, err)
@@ -86,18 +94,13 @@ Here are some updates, I hope they work.
 
 #### github.com/foo/bar@v99.88.77
 
-`+"```json"+`
-{
-  "major": true,
-  "minor": false,
-  "patch": false
-}
-`+"```"), strings.TrimSpace(body))
+<!--::action-update-go::
+{"updates":[{"path":"github.com/aws/aws-sdk-go","previous":"v1.34.16","next":"v1.34.17"},{"path":"github.com/foo/bar","previous":"v0.4.1","next":"v99.88.77"}],"signature":"TL6d3v5DKRu8uDY5doooDLLd7mJDHx6U5P4jRZYanLT4VI1dzt1gIRvZGW3G0ZlDQqmuTOftovTlwLHO1VW4Xw=="}
+-->
+`), strings.TrimSpace(body))
 }
 
 func TestNewSignedUpdateDescriptor(t *testing.T) {
-	key := []byte{1, 2, 3, 4}
-
 	cases := []struct {
 		signature string
 		updates   []updater.Update
@@ -118,7 +121,7 @@ func TestNewSignedUpdateDescriptor(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%v", tc.updates), func(t *testing.T) {
-			descriptor, err := repo.NewSignedUpdateDescriptor(key, tc.updates...)
+			descriptor, err := repo.NewSignedUpdateDescriptor(testKey, tc.updates...)
 			require.NoError(t, err)
 
 			buf, err := json.Marshal(&descriptor)
@@ -128,7 +131,7 @@ func TestNewSignedUpdateDescriptor(t *testing.T) {
 			assert.Equal(t, tc.updates, descriptor.Updates)
 			assert.Equal(t, tc.signature, base64.StdEncoding.EncodeToString(descriptor.Signature))
 
-			verified, err := repo.VerifySignedUpdateDescriptor(key, descriptor)
+			verified, err := repo.VerifySignedUpdateDescriptor(testKey, descriptor)
 			require.NoError(t, err)
 			assert.Equal(t, tc.updates, verified)
 		})

--- a/repo/pullrequest_test.go
+++ b/repo/pullrequest_test.go
@@ -2,6 +2,9 @@ package repo_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -90,4 +93,49 @@ Here are some updates, I hope they work.
   "patch": false
 }
 `+"```"), strings.TrimSpace(body))
+}
+
+func TestNewSignedUpdateDescriptor(t *testing.T) {
+	key := []byte{1, 2, 3, 4}
+
+	cases := []struct {
+		signature string
+		updates   []updater.Update
+	}{
+		{
+			signature: "HAF6zSdBBOsbrLRClce7M73tN7VhCdPB6YYhECL/ifDC6DHR0YSGXoY6JQeEaFoncJbxp/afBpY+GVE5DUfWwQ==",
+			updates:   []updater.Update{awsSdkGo13417},
+		},
+		{
+			signature: "kq9CbO3rYkThJPiJgVTfhkfAG4q5aEeXuta0x3wPVdUnqQhitA/FasfJ2WftpfiZvueCnknoX04yxTM94BUn4A==",
+			updates:   []updater.Update{fooBar987},
+		},
+		{
+			signature: "TL6d3v5DKRu8uDY5doooDLLd7mJDHx6U5P4jRZYanLT4VI1dzt1gIRvZGW3G0ZlDQqmuTOftovTlwLHO1VW4Xw==",
+			updates:   []updater.Update{awsSdkGo13417, fooBar987},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc.updates), func(t *testing.T) {
+			descriptor, err := repo.NewSignedUpdateDescriptor(key, tc.updates...)
+			require.NoError(t, err)
+
+			buf, err := json.Marshal(&descriptor)
+			require.NoError(t, err)
+			t.Log(string(buf))
+
+			assert.Equal(t, tc.updates, descriptor.Updates)
+			assert.Equal(t, tc.signature, base64.StdEncoding.EncodeToString(descriptor.Signature))
+
+			verified, err := repo.VerifySignedUpdateDescriptor(key, descriptor)
+			require.NoError(t, err)
+			assert.Equal(t, tc.updates, verified)
+		})
+	}
+}
+
+func TestVerifySignedUpdateDescriptor_Invalid(t *testing.T) {
+	_, err := repo.VerifySignedUpdateDescriptor([]byte{}, repo.SignedUpdateDescriptor{})
+	assert.EqualError(t, err, "invalid signature")
 }

--- a/repo/pullrequest_test.go
+++ b/repo/pullrequest_test.go
@@ -11,16 +11,25 @@ import (
 	"github.com/thepwagner/action-update-go/updater"
 )
 
+var (
+	awsSdkGo13417 = updater.Update{
+		Path:     "github.com/aws/aws-sdk-go",
+		Previous: "v1.34.16",
+		Next:     "v1.34.17",
+	}
+	fooBar987 = updater.Update{
+		Path:     "github.com/foo/bar",
+		Previous: "v0.4.1",
+		Next:     "v99.88.77",
+	}
+)
+
 func TestGitHubPullRequestContentGenerator_Generate(t *testing.T) {
 	token := tokenOrSkip(t)
 	client := repo.NewGitHubClient(token)
 	gen := repo.NewGitHubPullRequestContent(client)
 
-	title, body, err := gen.Generate(context.Background(), updater.Update{
-		Path:     "github.com/aws/aws-sdk-go",
-		Previous: "v1.34.16",
-		Next:     "v1.34.17",
-	})
+	title, body, err := gen.Generate(context.Background(), awsSdkGo13417)
 	require.NoError(t, err)
 	assert.Equal(t, "Update github.com/aws/aws-sdk-go from v1.34.16 to v1.34.17", title)
 	assert.Equal(t, strings.TrimSpace(`
@@ -42,15 +51,37 @@ func TestGitHubPullRequestContentGenerator_GenerateNoChangeLog(t *testing.T) {
 	client := repo.NewGitHubClient(token)
 	gen := repo.NewGitHubPullRequestContent(client)
 
-	title, body, err := gen.Generate(context.Background(), updater.Update{
-		Path:     "github.com/foo/bar",
-		Previous: "v0.4.1",
-		Next:     "v99.88.77",
-	})
+	title, body, err := gen.Generate(context.Background(), fooBar987)
 	require.NoError(t, err)
 	assert.Equal(t, "Update github.com/foo/bar from v0.4.1 to v99.88.77", title)
 	assert.Equal(t, strings.TrimSpace(`
 Here is github.com/foo/bar v99.88.77, I hope it works.
+
+`+"```json"+`
+{
+  "major": true,
+  "minor": false,
+  "patch": false
+}
+`+"```"), strings.TrimSpace(body))
+}
+
+func TestGitHubPullRequestContentGenerator_GenerateMultiple(t *testing.T) {
+	token := tokenOrSkip(t)
+	client := repo.NewGitHubClient(token)
+	gen := repo.NewGitHubPullRequestContent(client)
+
+	title, body, err := gen.Generate(context.Background(), awsSdkGo13417, fooBar987)
+	require.NoError(t, err)
+	assert.Equal(t, "Dependency Updates", title)
+	assert.Equal(t, strings.TrimSpace(`
+Here are some updates, I hope they work.
+
+#### github.com/aws/aws-sdk-go@v1.34.17
+
+[changelog](https://github.com/aws/aws-sdk-go/blob/v1.34.17/CHANGELOG.md)
+
+#### github.com/foo/bar@v99.88.77
 
 `+"```json"+`
 {

--- a/updater/mockrepo_test.go
+++ b/updater/mockrepo_test.go
@@ -43,12 +43,19 @@ func (_m *mockRepo) NewBranch(base string, branch string) error {
 }
 
 // Push provides a mock function with given fields: _a0, _a1
-func (_m *mockRepo) Push(_a0 context.Context, _a1 updater.Update) error {
-	ret := _m.Called(_a0, _a1)
+func (_m *mockRepo) Push(_a0 context.Context, _a1 ...updater.Update) error {
+	_va := make([]interface{}, len(_a1))
+	for _i := range _a1 {
+		_va[_i] = _a1[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, updater.Update) error); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, ...updater.Update) error); ok {
+		r0 = rf(_a0, _a1...)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/updater/update.go
+++ b/updater/update.go
@@ -7,11 +7,11 @@ import (
 // Update is change in version to a specific module path
 type Update struct {
 	// Path of module being updated
-	Path string
+	Path string `json:"path"`
 	// Previous module version
-	Previous string
+	Previous string `json:"previous"`
 	// Next module version
-	Next string
+	Next string `json:"next"`
 }
 
 type UpdatesByBranch map[string]Updates

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -28,7 +28,7 @@ type Repo interface {
 	Branch() string
 	// Push snapshots the working tree after an update has been applied, and "publishes".
 	// This is branch to commit. Publishing may mean push, create a PR, tweet the maintainer, whatever.
-	Push(context.Context, Update) error
+	Push(context.Context, ...Update) error
 }
 
 type Updater interface {
@@ -190,15 +190,7 @@ func (u *RepoUpdater) batchedUpdate(ctx context.Context, base, batchName string,
 		}
 	}
 
-	var update Update
-	if len(updates) == 1 {
-		update = updates[0]
-	} else {
-		// TODO: awkward for GitHubRepo, which will try to link a changelog here?
-		update = Update{Path: branch}
-	}
-
-	if err := u.repo.Push(ctx, update); err != nil {
+	if err := u.repo.Push(ctx, updates...); err != nil {
 		return fmt.Errorf("pushing update: %w", err)
 	}
 

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -109,7 +109,7 @@ func TestRepoUpdater_UpdateAll_MultipleBatch(t *testing.T) {
 
 	r.On("NewBranch", baseBranch, "action-update-go/main/foo").Times(1).Return(nil)
 	u.On("ApplyUpdate", ctx, mock.Anything).Times(2).Return(nil)
-	r.On("Push", ctx, mock.Anything).Times(1).Return(nil)
+	r.On("Push", ctx, mock.Anything, mock.Anything).Times(1).Return(nil)
 
 	err := ru.UpdateAll(ctx, baseBranch)
 	require.NoError(t, err)


### PR DESCRIPTION
Continues #53, extending `Repo.Push()` to accept varargs `[]updater.Updater`.

This allows batched updates to include details about every update, replacing the generic "multiple updates" placeholders and finishing a `TODO`.

In `GitHubRepo.Push()`, the `{major:, minor:, patch:}` visible blob in PRs is replaced with an invisible HMAC-ed blob that encodes the full update details.
This will eventually be parsed, bringing back the ability to skip updates that have closed PRs. Previously that relied on parsing the target update from branch names, but that branch naming became optional with batched updates.