### PR TITLE
Remove BranchNamer.Parse

### DIFF
--- a/actions/pullrequest.go
+++ b/actions/pullrequest.go
@@ -30,22 +30,23 @@ func PullRequest(ctx context.Context, env *cmd.Environment, evt interface{}) err
 var _ cmd.Handler = PullRequest
 
 func prReopened(ctx context.Context, env *cmd.Environment, pr *github.PullRequestEvent) error {
-	_, updater, err := getRepoUpdater(env)
-	if err != nil {
-		return err
-	}
+	//_, updater, err := getRepoUpdater(env)
+	//if err != nil {
+	//	return err
+	//}
 
 	prRef := pr.GetPullRequest().GetHead().GetRef()
 	logrus.WithField("ref", prRef).Info("PR reopened, recreating update")
 
-	base, update := updater.Parse(prRef)
-	if update == nil {
-		logrus.Info("not an update PR")
-		return nil
-	}
-
-	if err := updater.Update(ctx, base, *update); err != nil {
-		return fmt.Errorf("performing update: %w", err)
-	}
+	// FIXME: SignedUpdate parsing goes here
+	//base, update := updater.Parse(prRef)
+	//if update == nil {
+	//	logrus.Info("not an update PR")
+	//	return nil
+	//}
+	//
+	//if err := updater.Update(ctx, base, *update); err != nil {
+	//	return fmt.Errorf("performing update: %w", err)
+	//}
 	return nil
 }

--- a/actions/pullrequest_test.go
+++ b/actions/pullrequest_test.go
@@ -1,0 +1,37 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/thepwagner/action-update-go/cmd"
+)
+
+func TestPullRequest_UnhandledAction(t *testing.T) {
+	ctx := context.Background()
+	err := PullRequest(ctx, nil, &github.PullRequestEvent{
+		Action: github.String("unlocked"),
+	})
+	assert.NoError(t, err)
+}
+
+func TestPullRequest_Reopened_NoSignature(t *testing.T) {
+	ctx := context.Background()
+	err := PullRequest(ctx, &cmd.Environment{}, &github.PullRequestEvent{
+		Action: github.String("reopened"),
+	})
+	assert.NoError(t, err)
+}
+
+func TestPullRequest_Reopened_InvalidSignature(t *testing.T) {
+	ctx := context.Background()
+	err := PullRequest(ctx, &cmd.Environment{}, &github.PullRequestEvent{
+		Action: github.String("reopened"),
+		PullRequest: &github.PullRequest{
+			Body: github.String("<!--::action-update-go::{}-->"),
+		},
+	})
+	assert.EqualError(t, err, "invalid signature")
+}

--- a/repo/pullrequest.go
+++ b/repo/pullrequest.go
@@ -44,6 +44,16 @@ const (
 )
 
 func (d *GitHubPullRequestContent) ParseBody(s string) []updater.Update {
+	signed := ExtractSignedUpdateDescriptor(s)
+	if signed == nil {
+		return nil
+	}
+
+	updates, _ := updater.VerifySignedUpdateDescriptor(d.key, *signed)
+	return updates
+}
+
+func ExtractSignedUpdateDescriptor(s string) *updater.SignedUpdateDescriptor {
 	lastOpen := strings.LastIndex(s, openToken)
 	if lastOpen == -1 {
 		return nil
@@ -55,9 +65,7 @@ func (d *GitHubPullRequestContent) ParseBody(s string) []updater.Update {
 	if err := json.Unmarshal([]byte(raw), &signed); err != nil {
 		return nil
 	}
-
-	updates, _ := updater.VerifySignedUpdateDescriptor(d.key, signed)
-	return updates
+	return &signed
 }
 
 func (d *GitHubPullRequestContent) bodySingle(ctx context.Context, update updater.Update) (string, error) {

--- a/repo/pullrequest_test.go
+++ b/repo/pullrequest_test.go
@@ -2,9 +2,6 @@ package repo_test
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -98,47 +95,4 @@ Here are some updates, I hope they work.
 {"updates":[{"path":"github.com/aws/aws-sdk-go","previous":"v1.34.16","next":"v1.34.17"},{"path":"github.com/foo/bar","previous":"v0.4.1","next":"v99.88.77"}],"signature":"TL6d3v5DKRu8uDY5doooDLLd7mJDHx6U5P4jRZYanLT4VI1dzt1gIRvZGW3G0ZlDQqmuTOftovTlwLHO1VW4Xw=="}
 -->
 `), strings.TrimSpace(body))
-}
-
-func TestNewSignedUpdateDescriptor(t *testing.T) {
-	cases := []struct {
-		signature string
-		updates   []updater.Update
-	}{
-		{
-			signature: "HAF6zSdBBOsbrLRClce7M73tN7VhCdPB6YYhECL/ifDC6DHR0YSGXoY6JQeEaFoncJbxp/afBpY+GVE5DUfWwQ==",
-			updates:   []updater.Update{awsSdkGo13417},
-		},
-		{
-			signature: "kq9CbO3rYkThJPiJgVTfhkfAG4q5aEeXuta0x3wPVdUnqQhitA/FasfJ2WftpfiZvueCnknoX04yxTM94BUn4A==",
-			updates:   []updater.Update{fooBar987},
-		},
-		{
-			signature: "TL6d3v5DKRu8uDY5doooDLLd7mJDHx6U5P4jRZYanLT4VI1dzt1gIRvZGW3G0ZlDQqmuTOftovTlwLHO1VW4Xw==",
-			updates:   []updater.Update{awsSdkGo13417, fooBar987},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(fmt.Sprintf("%v", tc.updates), func(t *testing.T) {
-			descriptor, err := repo.NewSignedUpdateDescriptor(testKey, tc.updates...)
-			require.NoError(t, err)
-
-			buf, err := json.Marshal(&descriptor)
-			require.NoError(t, err)
-			t.Log(string(buf))
-
-			assert.Equal(t, tc.updates, descriptor.Updates)
-			assert.Equal(t, tc.signature, base64.StdEncoding.EncodeToString(descriptor.Signature))
-
-			verified, err := repo.VerifySignedUpdateDescriptor(testKey, descriptor)
-			require.NoError(t, err)
-			assert.Equal(t, tc.updates, verified)
-		})
-	}
-}
-
-func TestVerifySignedUpdateDescriptor_Invalid(t *testing.T) {
-	_, err := repo.VerifySignedUpdateDescriptor([]byte{}, repo.SignedUpdateDescriptor{})
-	assert.EqualError(t, err, "invalid signature")
 }

--- a/updater/branch.go
+++ b/updater/branch.go
@@ -2,16 +2,16 @@ package updater
 
 import (
 	"path"
-	"strings"
 )
 
 const branchPrefix = "action-update-go"
 
 // UpdateBranchNamer names branches for proposed updates.
 type UpdateBranchNamer interface {
+	// Format generates branch name for an update
 	Format(baseBranch string, update Update) string
+	// Format generates branch name for batch of updates
 	FormatBatch(baseBranch, batchName string) string
-	Parse(string) (baseBranch string, update *Update)
 }
 
 type DefaultUpdateBranchNamer struct{}
@@ -24,16 +24,4 @@ func (d DefaultUpdateBranchNamer) Format(baseBranch string, update Update) strin
 
 func (d DefaultUpdateBranchNamer) FormatBatch(baseBranch, batchName string) string {
 	return path.Join(branchPrefix, baseBranch, batchName)
-}
-
-func (d DefaultUpdateBranchNamer) Parse(branch string) (baseBranch string, u *Update) {
-	branchSplit := strings.Split(branch, "/")
-	if len(branchSplit) < 4 || branchSplit[0] != branchPrefix {
-		return "", nil
-	}
-	versPos := len(branchSplit) - 1
-	return branchSplit[1], &Update{
-		Path: path.Join(branchSplit[2:versPos]...),
-		Next: branchSplit[versPos],
-	}
 }

--- a/updater/branch_test.go
+++ b/updater/branch_test.go
@@ -8,27 +8,23 @@ import (
 	"github.com/thepwagner/action-update-go/updater"
 )
 
-func TestDefaultUpdateBranchNamer(t *testing.T) {
+func TestDefaultUpdateBranchNamer_Format(t *testing.T) {
 	const baseBranch = "main"
 	branchNamer := updater.DefaultUpdateBranchNamer{}
 
 	cases := []struct {
 		branch string
-		update *updater.Update
+		update updater.Update
 	}{
 		{
-			branch: "my-awesome-branch",
-			update: nil,
-		},
-		{
-			update: &updater.Update{
+			update: updater.Update{
 				Path: "github.com/foo/bar",
 				Next: "v1.2.3",
 			},
 			branch: "action-update-go/main/github.com/foo/bar/v1.2.3",
 		},
 		{
-			update: &updater.Update{
+			update: updater.Update{
 				Path:     "github.com/foo/bar/v2",
 				Previous: "v2.0.0",
 				Next:     "v3.0.0",
@@ -36,7 +32,7 @@ func TestDefaultUpdateBranchNamer(t *testing.T) {
 			branch: "action-update-go/main/github.com/foo/bar/v2/v3.0.0",
 		},
 		{
-			update: &updater.Update{
+			update: updater.Update{
 				Path:     "github.com/foo/bar",
 				Previous: "v2.0.0",
 				Next:     "v3.0.0",
@@ -47,20 +43,8 @@ func TestDefaultUpdateBranchNamer(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%v", c.branch), func(t *testing.T) {
-			base, up := branchNamer.Parse(c.branch)
-
-			if c.update != nil {
-				assert.Equal(t, baseBranch, base)
-				assert.Equal(t, c.update.Path, up.Path)
-				assert.Equal(t, c.update.Next, up.Next)
-
-				formatted := branchNamer.Format(baseBranch, *c.update)
-				assert.Equal(t, c.branch, formatted)
-			} else {
-				assert.Equal(t, "", base)
-				assert.Equal(t, "", base)
-				assert.Nil(t, c.update)
-			}
+			branch := branchNamer.Format(baseBranch, c.update)
+			assert.Equal(t, c.branch, branch)
 		})
 	}
 }

--- a/updater/signed.go
+++ b/updater/signed.go
@@ -1,0 +1,48 @@
+package updater
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+type SignedUpdateDescriptor struct {
+	Updates   []Update `json:"updates"`
+	Signature []byte   `json:"signature"`
+}
+
+func NewSignedUpdateDescriptor(key []byte, updates ...Update) (SignedUpdateDescriptor, error) {
+	signature, err := updatesHash(key, updates)
+	if err != nil {
+		return SignedUpdateDescriptor{}, err
+	}
+	return SignedUpdateDescriptor{
+		Updates:   updates,
+		Signature: signature,
+	}, nil
+}
+
+func updatesHash(key []byte, updates []Update) ([]byte, error) {
+	sort.Slice(updates, func(i, j int) bool {
+		return updates[i].Path < updates[j].Path
+	})
+	hash := hmac.New(sha512.New, key)
+	if err := json.NewEncoder(hash).Encode(updates); err != nil {
+		return nil, err
+	}
+	return hash.Sum(nil), nil
+}
+
+func VerifySignedUpdateDescriptor(key []byte, descriptor SignedUpdateDescriptor) ([]Update, error) {
+	calculated, err := updatesHash(key, descriptor.Updates)
+	if err != nil {
+		return nil, fmt.Errorf("calculating signature: %w", err)
+	}
+	if subtle.ConstantTimeCompare(calculated, descriptor.Signature) != 1 {
+		return nil, fmt.Errorf("invalid signature")
+	}
+	return descriptor.Updates, nil
+}

--- a/updater/signed_test.go
+++ b/updater/signed_test.go
@@ -1,0 +1,64 @@
+package updater_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thepwagner/action-update-go/updater"
+)
+
+var (
+	testKey = []byte{1, 2, 3, 4}
+)
+
+func TestNewSignedUpdateDescriptor(t *testing.T) {
+	var (
+		update1 = updater.Update{Path: "github.com/foo/bar", Previous: "v1.0.0", Next: "v1.1.0"}
+		update2 = updater.Update{Path: "github.com/foo/baz", Previous: "v1.0.0", Next: "v2.0.0"}
+	)
+
+	cases := []struct {
+		signature string
+		updates   []updater.Update
+	}{
+		{
+			signature: "TCQ5Vfa1pOKaMIhVpxVOWS/EzTuq+5AFfwrO8cuKxhes/hJ6xDrusp2YtFz2Vbc+pOYyu5oLbQBnyc9REk5mfA==",
+			updates:   []updater.Update{update1},
+		},
+		{
+			signature: "2H4Ka0Yzk5GyGRGusbZMLYdi+7a+EHJVmArdFLgFLBVzqNTDdnimHNbHym5v38h/lO8f2sObzVQPewa3TiytFw==",
+			updates:   []updater.Update{update1, update2},
+		},
+		{
+			signature: "2H4Ka0Yzk5GyGRGusbZMLYdi+7a+EHJVmArdFLgFLBVzqNTDdnimHNbHym5v38h/lO8f2sObzVQPewa3TiytFw==",
+			updates:   []updater.Update{update2, update1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc.updates), func(t *testing.T) {
+			descriptor, err := updater.NewSignedUpdateDescriptor(testKey, tc.updates...)
+			require.NoError(t, err)
+
+			buf, err := json.Marshal(&descriptor)
+			require.NoError(t, err)
+			t.Log(string(buf))
+
+			assert.Equal(t, tc.updates, descriptor.Updates)
+			assert.Equal(t, tc.signature, base64.StdEncoding.EncodeToString(descriptor.Signature))
+
+			verified, err := updater.VerifySignedUpdateDescriptor(testKey, descriptor)
+			require.NoError(t, err)
+			assert.Equal(t, tc.updates, verified)
+		})
+	}
+}
+
+func TestVerifySignedUpdateDescriptor_Invalid(t *testing.T) {
+	_, err := updater.VerifySignedUpdateDescriptor([]byte{}, updater.SignedUpdateDescriptor{})
+	assert.EqualError(t, err, "invalid signature")
+}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -59,19 +59,19 @@ func WithBatches(batchConfig map[string][]string) RepoUpdaterOpt {
 }
 
 // Update creates a single update branch in the Repo.
-func (u *RepoUpdater) Update(ctx context.Context, baseBranch string, update Update) error {
-	if err := u.repo.NewBranch(baseBranch, u.branchNamer.Format(baseBranch, update)); err != nil {
+func (u *RepoUpdater) Update(ctx context.Context, baseBranch, branchName string, updates ...Update) error {
+	if err := u.repo.NewBranch(baseBranch, branchName); err != nil {
 		return fmt.Errorf("switching to target branch: %w", err)
 	}
-
-	if err := u.updater.ApplyUpdate(ctx, update); err != nil {
-		return fmt.Errorf("applying update: %w", err)
+	for _, update := range updates {
+		if err := u.updater.ApplyUpdate(ctx, update); err != nil {
+			return fmt.Errorf("applying update: %w", err)
+		}
 	}
 
-	if err := u.repo.Push(ctx, update); err != nil {
+	if err := u.repo.Push(ctx, updates...); err != nil {
 		return fmt.Errorf("pushing update: %w", err)
 	}
-
 	return nil
 }
 

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -196,7 +196,3 @@ func (u *RepoUpdater) batchedUpdate(ctx context.Context, base, batchName string,
 
 	return nil
 }
-
-func (u *RepoUpdater) Parse(branch string) (baseBranch string, update *Update) {
-	return u.branchNamer.Parse(branch)
-}

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -19,17 +19,18 @@ func TestRepoUpdater_Update(t *testing.T) {
 	ru := updater.NewRepoUpdater(r, u)
 	ctx := context.Background()
 
-	setupMockUpdate(ctx, r, u, mockUpdate)
+	branch := setupMockUpdate(ctx, r, u, mockUpdate)
 
-	err := ru.Update(ctx, baseBranch, mockUpdate)
+	err := ru.Update(ctx, baseBranch, branch, mockUpdate)
 	require.NoError(t, err)
 }
 
-func setupMockUpdate(ctx context.Context, r *mockRepo, u *mockUpdater, up updater.Update) {
+func setupMockUpdate(ctx context.Context, r *mockRepo, u *mockUpdater, up updater.Update) string {
 	branch := fmt.Sprintf("action-update-go/main/%s/%s", up.Path, up.Next)
 	r.On("NewBranch", baseBranch, branch).Return(nil)
 	u.On("ApplyUpdate", ctx, up).Return(nil)
 	r.On("Push", ctx, up).Return(nil)
+	return branch
 }
 
 func TestRepoUpdater_UpdateAll_NoChanges(t *testing.T) {


### PR DESCRIPTION
Continuing from #71 , we can parse the `SignedUpdateDescriptor` from the PR description - that's a better source of truth than the PR's branch.

Then since nothing is using that code any more, ✂️ .