### PR TITLE
Update golang from 1.15.0 to 1.15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.0 AS builder
+FROM golang:1.15.3 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.15.3, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.15.0","next":"1.15.3"}]},"signature":"o7e4hVksO7pdG43QIOmCAgPJyPSnsv7XnJh0r/wkh2WIGNAA4J2yQcvKdoui1h0GX6DQoX9zcFdKMKC/KVV3+A=="}
-->