### PR TITLE
script/sync-actions-go-version

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -25,3 +25,7 @@ jobs:
         with:
           log_level: debug
           token: ${{ secrets.MY_GITHUB_PAT }}
+          groups: |
+            - name: golang
+              pattern: golang
+              post-script: script/sync-actions-go-version

--- a/script/sync-actions-go-version
+++ b/script/sync-actions-go-version
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+GO_VERSION="$(head -n1 Dockerfile | sed -e 's/.*://g' -e 's/ .*//g')"
+
+for f in .github/workflows/*; do
+  sed -i '' -e "s/go-version: .*/go-version: '$GO_VERSION'/g" "$f"
+done


### PR DESCRIPTION
This script updates the `go-version` input passed to https://github.com/actions/setup-go to align with the version specified in `Dockerfile`.

When configured as a `post-script` hook on the `golang` docker group, it makes https://github.com/thepwagner/action-update-go/pull/89 that much better 🤞 .