### PR TITLE
Update github.com/thepwagner/action-update from  to v0.0.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/dependabot/gomodules-extracted v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.24
+	github.com/thepwagner/action-update v0.0.26
 	golang.org/x/mod v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/thepwagner/action-update v0.0.24 h1:bPNQ4bxsPOzksFARyTyO+Qv1llQpi4/psbOvXHjVdqY=
-github.com/thepwagner/action-update v0.0.24/go.mod h1:2lUx9ybD0qJrfpZWzPvm2pHmfuuS86An7R3UTNq+prM=
+github.com/thepwagner/action-update v0.0.26 h1:4Zw2WHaZB26V+3cbRQGjGk6tcK+RIVX0fgVe1nMnlEw=
+github.com/thepwagner/action-update v0.0.26/go.mod h1:2lUx9ybD0qJrfpZWzPvm2pHmfuuS86An7R3UTNq+prM=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/sirupsen/logrus
 ## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.24
+# github.com/thepwagner/action-update v0.0.26
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.26, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/thepwagner/action-update","previous":"","next":"v0.0.26"}]},"signature":"eT64g1rowHd2jcvnaMdMrt3G5LJoqlewL5F6rXZnlEFxTZmZQ8TjjafvZ4bcfQC74SEW/X+k/1oPjrSBCOLJrg=="}
-->