### PR TITLE
Update github.com/thepwagner/action-update from  to v0.0.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/dependabot/gomodules-extracted v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.27
+	github.com/thepwagner/action-update v0.0.28
 	golang.org/x/mod v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/thepwagner/action-update v0.0.27 h1:5wZCtYJU6jLX1ypTIXtTc3l0QH8QJM3QqQlYHnBvkFs=
-github.com/thepwagner/action-update v0.0.27/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
+github.com/thepwagner/action-update v0.0.28 h1:503klKa9TbArCObpzZwkD9DV+FjW0u0dOU+VuK6LmEc=
+github.com/thepwagner/action-update v0.0.28/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/vendor/github.com/thepwagner/action-update/actions/handlers.go
+++ b/vendor/github.com/thepwagner/action-update/actions/handlers.go
@@ -99,11 +99,11 @@ func (h *Handlers) handler(event string) func(context.Context, interface{}) erro
 		}
 
 	case "workflow_dispatch":
-		if h.Schedule == nil {
+		if h.WorkflowDispatch == nil {
 			return nil
 		}
 		return func(ctx context.Context, _ interface{}) error {
-			return h.Schedule(ctx)
+			return h.WorkflowDispatch(ctx)
 		}
 
 	default:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/sirupsen/logrus
 ## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.27
+# github.com/thepwagner/action-update v0.0.28
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.28, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/thepwagner/action-update","previous":"","next":"v0.0.28"}]},"signature":"Hso+a/OlZB1e3KXRGVbzGu/x40FPjIB+ONytAbQ6V8cwh0b6oaImW4fRdzBpAo24GkAlgX9WjL/GpMfMXuzADg=="}
-->