### PR TITLE
Update golang from 1.15.5 to 1.15.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.5'
+        go-version: '1.15.6'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.MY_GITHUB_PAT }}
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.6'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5 AS builder
+FROM golang:1.15.6 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.15.6, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.5","next":"1.15.6"}]},"signature":"KDwy37m19lWaQU3qehs8JAFiV1sVUE6JzdCzfIS2o5X9IykXk40wm3OcrIZeExDYxjfVYV/ecq8MKh3BsldAjA=="}
-->