### PR TITLE
Update golangci/golangci-lint from v1.35.0-alpine to v1.35.2-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.35.0-alpine
+FROM golangci/golangci-lint:v1.35.2-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.35.2-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.35.0-alpine","next":"v1.35.2-alpine"}]},"signature":"kQnOz59RMm8BPO5WTpiEiojdwBA+VTk8stVNSkwH89iNASLzJwZM09g6iyQDE1YJPWnJQ0czycDlKsUaDNM0qg=="}
-->