### PR TITLE
Update golang.org/x/mod from v0.4.0 to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/thepwagner/action-update v0.0.37
-	golang.org/x/mod v0.4.0
+	golang.org/x/mod v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqp
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -150,7 +150,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
-# golang.org/x/mod v0.4.0
+# golang.org/x/mod v0.4.1
 ## explicit
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/modfile


### PR DESCRIPTION
Here is golang.org/x/mod v0.4.1, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang.org/x/mod","previous":"v0.4.0","next":"v0.4.1"}]},"signature":"SqIxHW04p8yjy3GjsEXkvFFPT4xQUPgOk2Z6TcVkLAQhE/sgT0JI+dWU0xJ03tHMdHOWiJTy2mPw/vZQF0rJaQ=="}
-->