### PR TITLE
Update golang from 1.15.6 to 1.15.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.6'
+        go-version: '1.15.7'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.6'
+          go-version: '1.15.7'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6 AS builder
+FROM golang:1.15.7 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.15.7, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.6","next":"1.15.7"}]},"signature":"wAUgVx7TBjF6t+bGO+Snv5DDDRrHGeNbl8oECgvSq8XVkQWpmaZkdggo/vYpgrzMkfljoH1+gTogdctO+TDrmg=="}
-->