### PR TITLE
Update golangci/golangci-lint from v1.35.2-alpine to v1.36.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.35.2-alpine
+FROM golangci/golangci-lint:v1.36.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.36.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.35.2-alpine","next":"v1.36.0-alpine"}]},"signature":"U4qx5nEWThjJS8XMAX575giWfmZqMrJypv0cxYeJvHXFR+MriFN3M15PcXVUyfFrUCdf9AqcNlv0FpUvWv3nYg=="}
-->