### PR TITLE
Update golangci/golangci-lint from v1.36.0-alpine to v1.37.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.36.0-alpine
+FROM golangci/golangci-lint:v1.37.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.37.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.36.0-alpine","next":"v1.37.0-alpine"}]},"signature":"wugV2Tuu22AOAFmMMPR3f1WBB5xAoZ5AWRWjP4jefKjt262y/eIigraw5nf/OyVPlNjaO82A5DnCcsRf/x/jtA=="}
-->