### PR TITLE
Update golangci/golangci-lint from v1.37.1-alpine to v1.38.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.37.1-alpine
+FROM golangci/golangci-lint:v1.38.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.38.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.37.1-alpine","next":"v1.38.0-alpine"}]},"signature":"p0EYi8E1SiWCoI1qsNTEfldpEtEZbhtSj+ow6J1jg+MQ+Nzk1qIzn04oFyqUzasPb7GBVF0Zj2GMxEztYfwYmw=="}
-->