### PR TITLE
Update golang from 1.16.0 to 1.16.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.0'
+        go-version: '1.16.1'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.0'
+          go-version: '1.16.1'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.0 AS builder
+FROM golang:1.16.1 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.16.1, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.16.0","next":"1.16.1"}]},"signature":"hJu3AnBRTk0KVsG9HWN4VXRAf7OML7sEMt0C8AR0w/wwxb99sd0vvS105HFZMNt9+UIpNlx3B3a/a5V3HHLJow=="}
-->