### PR TITLE
Update golangci/golangci-lint from v1.39.0-alpine to v1.40.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.39.0-alpine
+FROM golangci/golangci-lint:v1.40.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.40.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.39.0-alpine","next":"v1.40.0-alpine"}]},"signature":"Cz0oxG76my602eel+F34ZNiwm94OJVYJN72UaJKHwS342gIvdkLsskspURcAufl9S2BESlr5ZQbwg+mMydS4hA=="}
-->